### PR TITLE
fix: skapm dependency specification

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -29,9 +29,9 @@
  (name ecs-apm)
  (synopsis "Helper library for APM integration with ECS")
  (depends
+  skapm
   (ocaml (>= 4.08.0))
   (ecs (= :version))
-  (skapm :build)
   (dune (>= 2.5.0))
   (fmt (>= 0.8.8))
   (logs (>= 0.7.0))

--- a/ecs-apm.opam
+++ b/ecs-apm.opam
@@ -7,9 +7,9 @@ license: "Apache-2.0"
 homepage: "https://github.com/skolemlabs/sklogs"
 bug-reports: "https://github.com/skolemlabs/sklogs/issues"
 depends: [
+  "skapm"
   "ocaml" {>= "4.08.0"}
   "ecs" {= version}
-  "skapm" {build}
   "dune" {>= "2.5.0"}
   "fmt" {>= "0.8.8"}
   "logs" {>= "0.7.0"}


### PR DESCRIPTION
`:build` dependencies don't cause rebuilds on dependency updates, leading to annoying interface errors on compilation.